### PR TITLE
Bug se shows na for ten area model

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -98,7 +98,7 @@ create_movement_probability_results_std_err_4d <- function (pars,
                                                             covs,
                                                             dims,
                                                             tp_2d,
-                                                            results_units,
+                                                            result_units,
                                                             n_draws = 1000) {
 
   #---------------- Check arguments -------------------------------------------#
@@ -121,7 +121,7 @@ create_movement_probability_results_std_err_4d <- function (pars,
     #---------------- Draw parameters -----------------------------------------#
 
     par_devs <- MASS::mvrnorm(n = 1,
-                              mu = rep(0, np * ng),
+                              mu = rep(0, nv * np * ng),
                               Sigma = covs,
                               empirical = FALSE)
     par_draw <- pars + par_devs
@@ -145,7 +145,7 @@ create_movement_probability_results_std_err_4d <- function (pars,
 
     mpr_se_5d[, , , , i] <- create_movement_probability_results_4d(
       mp_4d = mp_4d,
-      result_units = results_units
+      result_units = result_units
     )
   }
 
@@ -156,7 +156,7 @@ create_movement_probability_results_std_err_4d <- function (pars,
     for (ca in seq_len(na)) {
       for (cv in seq_len(nv)) {
         for (mg in seq_len(ng)) {
-          mpr_se_4d[pa, ca, cv, mg] <- sd(mpr_se_5d[pa, ca, cv, mg, ])
+          mpr_se_4d[pa, ca, cv, mg] <- sd(mpr_se_5d[pa, ca, cv, mg, ], na.rm = TRUE)
         }
       }
     }
@@ -171,7 +171,7 @@ create_movement_probability_results <- function (pars,
                                                  covs,
                                                  dims,
                                                  tp_2d,
-                                                 results_units,
+                                                 result_units,
                                                  n_draws = 1000) {
 
   #---------------- Check arguments -------------------------------------------#
@@ -205,7 +205,7 @@ create_movement_probability_results <- function (pars,
 
   mpr_4d <- create_movement_probability_results_4d(
     mp_4d = mp_4d,
-    result_units = results_units
+    result_units = result_units
   )
 
   #---------------- Compute standard errors array -----------------------------#
@@ -215,7 +215,7 @@ create_movement_probability_results <- function (pars,
     covs = covs,
     dims = dims,
     tp_2d = tp_2d,
-    results_units = results_units,
+    result_units = result_units,
     n_draws = n_draws
   )
 

--- a/R/fit.R
+++ b/R/fit.R
@@ -212,7 +212,7 @@ mmmTMB <- function (released_3d, # Data
   if (!is.null(capture_map_2d)) {
     tmb_map <- c(tmb_map, list(log_capture_bias_2d = as.factor(capture_map_2d)))
   } else {
-    tmb_map <- c(tmb_map, list(log_capture_bias_2d = factor(seq_len(na * ng))))
+    tmb_map <- c(tmb_map, list(log_capture_bias_2d = factor(rep(1, na * ng))))
   }
 
   # Map off log_dispersion?
@@ -316,7 +316,7 @@ mmmTMB <- function (released_3d, # Data
     covs = covs,
     dims = c(nv, np, nt, na, ng),
     tp_2d = template_2d,
-    results_units = result_units,
+    result_units = result_units,
     n_draws = 1000)
   tictoc::toc()
 

--- a/data-raw/load_obs_data_for_testing.R
+++ b/data-raw/load_obs_data_for_testing.R
@@ -1,0 +1,29 @@
+# Load manually
+load("~/github/sablefishData/data/obs_released_3d_mon_10a_pool_sml.rda")
+load("~/github/sablefishData/data/obs_recovered_5d_mon_10a_pool_sml.rda")
+load("~/github/sablefishData/data/obs_capture_rate_2d_mon_10a.rda")
+load("~/github/sablefishData/data/obs_report_ratio_2d_mon_10a.rda")
+load("~/github/sablefishData/data/obs_template_2d_mon_10a.rda")
+
+# Define arguments for testing
+released_3d <- obs_released_3d_mon_10a_pool_sml
+recovered_5d <- obs_recovered_5d_mon_10a_pool_sml
+capture_rate_2d <- obs_capture_rate_2d_mon_10a
+report_ratio_2d <- obs_report_ratio_2d_mon_10a
+template_2d <- obs_template_2d_mon_10a
+tag_loss_rate <- 0.02 / 12 # Divide by 12
+imm_loss_ratio <- 0.1
+recapture_delay <- 1
+error_family <- 1
+result_units <- 12 # Check
+time_process <- 0
+time_pattern <- 0
+pattern_size <- 0
+newton_steps <- 0
+nlminb_loops <- 5
+openmp_cores <- floor(parallel::detectCores() / 2)
+capture_map_2d <- array(c(1, 1, 1, 1, 1, 2, 3, 3, 4, 4), dim = c(10, 1))
+structure_list <- NULL
+parameter_list <- NULL
+optimizer_list <- NULL
+nlminb_control <- mmmTMBcontrol()

--- a/tests/testthat/test-fit.R
+++ b/tests/testthat/test-fit.R
@@ -26,7 +26,8 @@ test_that("mmmTMB() computes SEs for size class release and recovery data", {
     tag_loss_rate = 0.02,
     imm_loss_ratio = 0.1,
     template_2d = sim_template_2d,
-    nlminb_loops = 5,
+    nlminb_loops = 10,
+    newton_steps = 1,
     openmp_cores = floor(parallel::detectCores() / 2))
   # Tests
   testthat::expect_true(sum(


### PR DESCRIPTION
Responds to issues: #16 #15 
Leads to issue: #17 

Chance `NaN`s were introduced by draws of large parameter values during bootstrapping of SEs. Current solution was to add `na.rm = TRUE` to `sd()` call. Please merge.